### PR TITLE
feat: Enable purchasing items

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ const App = () => {
     <Router>
       <Routes>
         <Route path="/" element={<Main />} />
+        <Route path="list/edit/:id" element={<List editable/>} />
         <Route path="list/:id" element={<List />} />
       </Routes>
     </Router>

--- a/src/BuyItemModal.tsx
+++ b/src/BuyItemModal.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+
+interface BuyItemModalProps {
+  id: number;
+  title: string;
+  quantity: number;
+  bought: number;
+  buyItem: (id: number, count: number) => void;
+  close: () => void;
+}
+
+const BuyItemModal = (props: BuyItemModalProps) => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <button className="close" onClick={() => props.close()}>
+          &times;
+        </button>
+        <p>How many {props.title} would you like to buy?</p>
+        <input
+          type="number"
+          value={count}
+          onInput={(ev) => {
+            const value = parseInt(ev.currentTarget.value);
+            if (value >= 0 && value <= (props.quantity - props.bought))
+              setCount(parseInt(ev.currentTarget.value));
+          }}
+        />
+        <button onClick={() => props.buyItem(props.id, count)}>Purchase</button>
+      </div>
+    </div>
+  );
+};
+
+export default BuyItemModal;

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -1,51 +1,72 @@
-import React from "react";
+import React, { useState } from "react";
 import { useParams } from "react-router";
 
 import ListItem from "./components/ListItem";
 
-const List = () => {
-  const params = useParams();
-  const id = params.id;
-  const buyerView = true;
+const ITEMS = [
+  {
+    id: 0,
+    title: "Pony",
+    description: "I want a pony",
+    quantity: 1,
+    bought: 0,
+  },
+  {
+    id: 1,
+    title: "Potato",
+    description:
+      "I have a grand plan to make a potato server and all that I'm missing is a potato.  I know it's possible because my tutor had them in a doc he shared with me.",
+    quantity: 1,
+    bought: 1,
+  },
+  {
+    id: 2,
+    title: "Things",
+    description:
+      "I reaaaallllllyyy reaaaallllyyy reaaallllyyy want a bunch of things. Like a lot of things.  ",
+    quantity: 100,
+    bought: 2,
+  },
+  {
+    id: 3,
+    title: "Lorem",
+    description:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    quantity: 3,
+    bought: 0,
+  },
+  {
+    id: 4,
+    title: "Pancakes",
+    description: "The good stuff only",
+    quantity: 50,
+    bought: 25,
+  },
+];
+
+interface ListProps {
+  editable?: boolean;
+}
+
+const List = (props: ListProps) => {
+  // const params = useParams();
+  // const id = params.id;
+  const [items, setItems] = useState(ITEMS);
+  const buyerView = !props.editable;
+
+  const buyItem = (id: number, count: number) => {
+    const idx = items.findIndex((item) => item.id === id);
+    items[idx].bought += count;
+    setItems([...items]);
+  };
 
   return (
     <div>
-      {id}
-      <ListItem
-        buyerView={buyerView}
-        title="Pony"
-        description="I want a pony"
-        quantity={1}
-        bought={0}
-      />
-      <ListItem
-        buyerView={buyerView}
-        title="Potato"
-        description="I have a grand plan to make a potato server and all that I'm missing is a potato.  I know it's possible because my tutor had them in a doc he shared with me."
-        quantity={1}
-        bought={1}
-      />
-      <ListItem
-        buyerView={buyerView}
-        title="Things"
-        description="I reaaaallllllyyy reaaaallllyyy reaaallllyyy want a bunch of things. Like a lot of things.  "
-        quantity={100}
-        bought={2}
-      />
-      <ListItem
-        buyerView={buyerView}
-        title="Lorem"
-        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-        quantity={3}
-        bought={0}
-      />
-      <ListItem
-        buyerView={buyerView}
-        title="Pancakes"
-        description="The good stuff only"
-        quantity={50}
-        bought={25}
-      />
+      {ITEMS.map((item) => (
+        <React.Fragment key={item.id}>
+          <ListItem {...item} buyerView={buyerView} buyItem={buyItem} />
+        </React.Fragment>
+      ))}
     </div>
   );
 };

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -1,40 +1,65 @@
 import React, { useState } from "react";
 import Cart from "../assets/cart.png";
 import Bin from "../assets/bin.png";
+import BuyItemModal from "../BuyItemModal";
 
-// buyerView: boolean, title: string, description: string, quantity: number, bought: number
-const ListItem = (props: any) => {
+interface ListItemProps {
+  buyerView: boolean;
+  id: number;
+  title: string;
+  description: string;
+  quantity: number;
+  bought: number;
+  buyItem: (id: number, count: number) => void;
+}
+
+const ListItem = (props: ListItemProps) => {
   const [expanded, setExpanded] = useState(false);
-  const quantityRemaining = props?.quantity - props?.bought;
+  const [openModal, setOpenModal] = useState(false);
+  const quantityRemaining = props.quantity - props.bought;
 
-  if (props?.buyerView && quantityRemaining == 0) return <></>;
+  if (props.buyerView && quantityRemaining == 0) return <></>;
 
   return (
-    <div className={`list-item-container ${expanded && "height-auto"}`}>
-      <div className="list-item-bar">
-        <div className="circle">
-          {props?.buyerView ? quantityRemaining : props?.quantity}
+    <>
+      {openModal && (
+        <BuyItemModal
+          id={props.id}
+          bought={props.bought}
+          title={props.title}
+          quantity={props.quantity}
+          buyItem={(id, count) => {
+            props.buyItem(id, count);
+            setOpenModal(false);
+          }}
+          close={() => setOpenModal(false)}
+        />
+      )}
+
+      <div className={`list-item-container ${expanded ? "height-auto" : ""}`}>
+        <div className="list-item-bar">
+          <div className="circle">
+            {props.buyerView ? quantityRemaining : props.quantity}
+          </div>
+          <h1 className="list-item-title">{props.title}</h1>
+          <div
+            className={`circle float-right ${expanded || "rotate"}`}
+            onClick={() => setExpanded(!expanded)}
+          >
+            {"🞃"}
+          </div>
         </div>
-        <h1 className="list-item-title">{props?.title}</h1>
-        <div
-          className={`circle float-right ${expanded || "rotate"}`}
-          onClick={() => setExpanded(!expanded)}
-        >
-          {"🞃"}
+
+        <div className={`content ${expanded ? "grow" : ""}`}>
+          <div className="description-container">
+            <p className="description">{props.description}</p>
+          </div>
+          <button className="circle" onClick={() => setOpenModal(true)}>
+            <img src={props.buyerView ? Cart : Bin} className="icon" />
+          </button>
         </div>
       </div>
-      {true && (
-        <div className={`content ${expanded && "grow"}`}>
-          {/* <div className="circle">{props?.quantity}</div> */}
-          <div className="description-container">
-            <p className="description">{props?.description}</p>
-          </div>
-          <div className="circle">
-            <img src={props?.buyerView ? Cart : Bin} className="icon" />
-          </div>
-        </div>
-      )}
-    </div>
+    </>
   );
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,8 @@ code {
   margin: 10px 0 0 0;
   max-height: 70px;
   transition-duration: 0.5s;
+  position: relative;
+  z-index: 0;
 }
 
 .height-auto {
@@ -77,8 +79,6 @@ code {
   padding: 10px;
   display: flex;
   justify-content: space-between;
-  /* justify-content: center; */
-  /* justify-content: space-evenly; */
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   margin-top: -35px;
@@ -100,11 +100,38 @@ code {
 }
 
 .description {
-  /* text-align: center; */
   margin: 0;
 }
 
 .icon {
   height: 30px;
   margin-top: 10px;
+}
+
+.modal {
+  display: block;
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0,0,0);
+  background-color: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+  background-color: #fefefe;
+  margin: 15% auto;
+  padding: 20px;
+  border: 1px solid #888;
+  width: 80%;
+}
+
+.close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
 }


### PR DESCRIPTION
## GitHub Issue Solved: #9 #16 

closes #9 #16

## Current behaviour
Currently it is not possible to indicate that a user has purchased an item

## Changed behaviour
A user can now click on the buy button, which will open a modal that can then be used to say how many of the items the buyer has purchased
